### PR TITLE
Remove HEAD request on the create_url function

### DIFF
--- a/api/createUrl.js
+++ b/api/createUrl.js
@@ -1,3 +1,6 @@
+// eslint-disable-next-line
+if (process.env.NODE_ENV !== "production") require("dotenv").config();
+
 const { GraphQLClient } = require("graphql-request");
 const secureRandom = require("secure-random-string");
 const validateUrl = require("./utils/validateUrl");

--- a/api/getUrl.js
+++ b/api/getUrl.js
@@ -1,3 +1,6 @@
+// eslint-disable-next-line
+if (process.env.NODE_ENV !== "production") require("dotenv").config();
+
 const { GraphQLClient } = require("graphql-request");
 
 const endpoint = "https://graphql.fauna.com/graphql";

--- a/api/index.js
+++ b/api/index.js
@@ -1,6 +1,3 @@
-// eslint-disable-next-line
-if (process.env.NODE_ENV !== "production") require("dotenv").config();
-
 const createUrl = require("./createUrl");
 const getUrl = require("./getUrl");
 

--- a/api/utils/validateUrl.js
+++ b/api/utils/validateUrl.js
@@ -1,5 +1,3 @@
-const axios = require("axios").default;
-
 // Credit https://gist.github.com/dperini/729294
 const urlRegex = new RegExp(
   "^" +
@@ -28,23 +26,6 @@ const urlRegex = new RegExp(
   "i",
 );
 
-/**
- * Visit the URL with a HEAD request
- * to check if the server is down or
- * the URL doesn't exist
- */
-async function visitUrl(url) {
-  try {
-    await axios.head(url);
-  } catch (error) {
-    if (!error.response) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
 module.exports = async function validateUrl(url) {
-  return urlRegex.test(url) && visitUrl(url);
+  return urlRegex.test(url);
 };


### PR DESCRIPTION
This fixes #6 

For some reason, our HEAD request that we made to validate URLs (to see if they are not only semantically correct but also valid "live" URLs) was erroring out for some sites on Netlify. In #6, mega.nz Cloudflare protection was blocking requests from Netlify (but not our local network).

This PR removes that for the time being until we find a better solution.